### PR TITLE
Fix 5 security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -673,9 +673,9 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "engines": {
                 "node": ">=8"
             }
@@ -5860,9 +5860,9 @@
             "dev": true
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "ansi-styles": {
             "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "axios": "^0.24.0",
                 "dotenv": "^10.0.0",
-                "next": "11.1.2",
+                "next": "11.1.3",
                 "react": "17.0.2",
                 "react-dom": "17.0.2",
                 "react-icons": "^4.3.1"
@@ -221,9 +221,9 @@
             "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
         },
         "node_modules/@next/env": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
-            "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA=="
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.3.tgz",
+            "integrity": "sha512-5+vaeooJuWmICSlmVaAC8KG3O8hwKasACVfkHj58xQuCB5SW0TKW3hWxgxkBuefMBn1nM0yEVPKokXCsYjBtng=="
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "11.1.2",
@@ -235,14 +235,14 @@
             }
         },
         "node_modules/@next/polyfill-module": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
-            "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA=="
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.3.tgz",
+            "integrity": "sha512-7yr9cr4a0SrBoVE8psxXWK1wTFc8UzsY8Wc2cWGL7qA0hgtqACHaXC47M1ByJB410hFZenGrpE+KFaT1unQMyw=="
         },
         "node_modules/@next/react-dev-overlay": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
-            "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.3.tgz",
+            "integrity": "sha512-zIwtMliSUR+IKl917ToFNB+0fD7bI5kYMdjHU/UEKpfIXAZPnXRHHISCvPDsczlr+bRsbjlUFW1CsNiuFedeuQ==",
             "dependencies": {
                 "@babel/code-frame": "7.12.11",
                 "anser": "1.4.9",
@@ -326,9 +326,9 @@
             }
         },
         "node_modules/@next/react-refresh-utils": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
-            "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.3.tgz",
+            "integrity": "sha512-144kD8q2nChw67V3AJJlPQ6NUJVFczyn10bhTynn9o2rY5DEnkzuBipcyMuQl2DqfxMkV7sn+yOCOYbrLCk9zg==",
             "peerDependencies": {
                 "react-refresh": "0.8.3",
                 "webpack": "^4 || ^5"
@@ -340,9 +340,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
-            "integrity": "sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.3.tgz",
+            "integrity": "sha512-TwP4krjhs+uU9pesDYCShEXZrLSbJr78p12e7XnLBBaNf20SgWLlVmQUT9gX9KbWan5V0sUbJfmcS8MRNHgYuA==",
             "cpu": [
                 "arm64"
             ],
@@ -355,9 +355,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz",
-            "integrity": "sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.3.tgz",
+            "integrity": "sha512-ZSWmkg/PxccHFNUSeBdrfaH8KwSkoeUtewXKvuYYt7Ph0yRsbqSyNIvhUezDua96lApiXXq6EL2d1THfeWomvw==",
             "cpu": [
                 "x64"
             ],
@@ -370,9 +370,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz",
-            "integrity": "sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.3.tgz",
+            "integrity": "sha512-PrTBN0iZudAuj4jSbtXcdBdmfpaDCPIneG4Oms4zcs93KwMgLhivYW082Mvlgx9QVEiRm7+RkFpIVtG/i7JitA==",
             "cpu": [
                 "x64"
             ],
@@ -385,9 +385,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz",
-            "integrity": "sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.3.tgz",
+            "integrity": "sha512-mRwbscVjRoHk+tDY7XbkT5d9FCwujFIQJpGp0XNb1i5OHCSDO8WW/C9cLEWS4LxKRbIZlTLYg1MTXqLQkvva8w==",
             "cpu": [
                 "x64"
             ],
@@ -3417,16 +3417,16 @@
             "dev": true
         },
         "node_modules/next": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
-            "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/next/-/next-11.1.3.tgz",
+            "integrity": "sha512-ud/gKmnKQ8wtHC+pd1ZiqPRa7DdgulPkAk94MbpsspfNliwZkYs9SIYWhlLSyg+c661LzdUI2nZshvrtggSYWA==",
             "dependencies": {
                 "@babel/runtime": "7.15.3",
                 "@hapi/accept": "5.0.2",
-                "@next/env": "11.1.2",
-                "@next/polyfill-module": "11.1.2",
-                "@next/react-dev-overlay": "11.1.2",
-                "@next/react-refresh-utils": "11.1.2",
+                "@next/env": "11.1.3",
+                "@next/polyfill-module": "11.1.3",
+                "@next/react-dev-overlay": "11.1.3",
+                "@next/react-refresh-utils": "11.1.3",
                 "@node-rs/helper": "1.2.1",
                 "assert": "2.0.0",
                 "ast-types": "0.13.2",
@@ -3479,10 +3479,10 @@
                 "node": ">=12.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "11.1.2",
-                "@next/swc-darwin-x64": "11.1.2",
-                "@next/swc-linux-x64-gnu": "11.1.2",
-                "@next/swc-win32-x64-msvc": "11.1.2"
+                "@next/swc-darwin-arm64": "11.1.3",
+                "@next/swc-darwin-x64": "11.1.3",
+                "@next/swc-linux-x64-gnu": "11.1.3",
+                "@next/swc-win32-x64-msvc": "11.1.3"
             },
             "peerDependencies": {
                 "fibers": ">= 3.1.0",
@@ -5565,9 +5565,9 @@
             "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
         },
         "@next/env": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
-            "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA=="
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.3.tgz",
+            "integrity": "sha512-5+vaeooJuWmICSlmVaAC8KG3O8hwKasACVfkHj58xQuCB5SW0TKW3hWxgxkBuefMBn1nM0yEVPKokXCsYjBtng=="
         },
         "@next/eslint-plugin-next": {
             "version": "11.1.2",
@@ -5579,14 +5579,14 @@
             }
         },
         "@next/polyfill-module": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
-            "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA=="
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.3.tgz",
+            "integrity": "sha512-7yr9cr4a0SrBoVE8psxXWK1wTFc8UzsY8Wc2cWGL7qA0hgtqACHaXC47M1ByJB410hFZenGrpE+KFaT1unQMyw=="
         },
         "@next/react-dev-overlay": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
-            "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.3.tgz",
+            "integrity": "sha512-zIwtMliSUR+IKl917ToFNB+0fD7bI5kYMdjHU/UEKpfIXAZPnXRHHISCvPDsczlr+bRsbjlUFW1CsNiuFedeuQ==",
             "requires": {
                 "@babel/code-frame": "7.12.11",
                 "anser": "1.4.9",
@@ -5647,33 +5647,33 @@
             }
         },
         "@next/react-refresh-utils": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
-            "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.3.tgz",
+            "integrity": "sha512-144kD8q2nChw67V3AJJlPQ6NUJVFczyn10bhTynn9o2rY5DEnkzuBipcyMuQl2DqfxMkV7sn+yOCOYbrLCk9zg==",
             "requires": {}
         },
         "@next/swc-darwin-arm64": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
-            "integrity": "sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.3.tgz",
+            "integrity": "sha512-TwP4krjhs+uU9pesDYCShEXZrLSbJr78p12e7XnLBBaNf20SgWLlVmQUT9gX9KbWan5V0sUbJfmcS8MRNHgYuA==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz",
-            "integrity": "sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.3.tgz",
+            "integrity": "sha512-ZSWmkg/PxccHFNUSeBdrfaH8KwSkoeUtewXKvuYYt7Ph0yRsbqSyNIvhUezDua96lApiXXq6EL2d1THfeWomvw==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz",
-            "integrity": "sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.3.tgz",
+            "integrity": "sha512-PrTBN0iZudAuj4jSbtXcdBdmfpaDCPIneG4Oms4zcs93KwMgLhivYW082Mvlgx9QVEiRm7+RkFpIVtG/i7JitA==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz",
-            "integrity": "sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.3.tgz",
+            "integrity": "sha512-mRwbscVjRoHk+tDY7XbkT5d9FCwujFIQJpGp0XNb1i5OHCSDO8WW/C9cLEWS4LxKRbIZlTLYg1MTXqLQkvva8w==",
             "optional": true
         },
         "@node-rs/helper": {
@@ -7969,20 +7969,20 @@
             "dev": true
         },
         "next": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
-            "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/next/-/next-11.1.3.tgz",
+            "integrity": "sha512-ud/gKmnKQ8wtHC+pd1ZiqPRa7DdgulPkAk94MbpsspfNliwZkYs9SIYWhlLSyg+c661LzdUI2nZshvrtggSYWA==",
             "requires": {
                 "@babel/runtime": "7.15.3",
                 "@hapi/accept": "5.0.2",
-                "@next/env": "11.1.2",
-                "@next/polyfill-module": "11.1.2",
-                "@next/react-dev-overlay": "11.1.2",
-                "@next/react-refresh-utils": "11.1.2",
-                "@next/swc-darwin-arm64": "11.1.2",
-                "@next/swc-darwin-x64": "11.1.2",
-                "@next/swc-linux-x64-gnu": "11.1.2",
-                "@next/swc-win32-x64-msvc": "11.1.2",
+                "@next/env": "11.1.3",
+                "@next/polyfill-module": "11.1.3",
+                "@next/react-dev-overlay": "11.1.3",
+                "@next/react-refresh-utils": "11.1.3",
+                "@next/swc-darwin-arm64": "11.1.3",
+                "@next/swc-darwin-x64": "11.1.3",
+                "@next/swc-linux-x64-gnu": "11.1.3",
+                "@next/swc-win32-x64-msvc": "11.1.3",
                 "@node-rs/helper": "1.2.1",
                 "assert": "2.0.0",
                 "ast-types": "0.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2431,9 +2431,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
+            "version": "1.14.7",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -7253,9 +7253,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.14.5",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-            "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
+            "version": "1.14.7",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
         },
         "foreach": {
             "version": "2.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,13 @@
                 "next": "11.1.3",
                 "react": "17.0.2",
                 "react-dom": "17.0.2",
-                "react-icons": "^4.3.1"
+                "react-icons": "^4.3.1",
+                "node-fetch": ">=2.6.7"
             },
             "devDependencies": {
                 "eslint": "7.32.0",
-                "eslint-config-next": "11.1.2"
+                "eslint-config-next": "11.1.2",
+                "node-fetch": ">=2.6.7"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
                 "next": "11.1.3",
                 "react": "17.0.2",
                 "react-dom": "17.0.2",
-                "react-icons": "^4.3.1",
-                "node-fetch": ">=2.6.7"
+                "react-icons": "^4.3.1"
             },
             "devDependencies": {
                 "eslint": "7.32.0",
@@ -3505,12 +3504,54 @@
                 }
             }
         },
-        "node_modules/node-fetch": {
+        "node_modules/next/node_modules/node-fetch": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
             "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
             "engines": {
                 "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dev": true,
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+            "dev": true
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+            "dev": true
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dev": true,
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/node-html-parser": {
@@ -8029,12 +8070,47 @@
                 "util": "0.12.4",
                 "vm-browserify": "1.1.2",
                 "watchpack": "2.1.1"
+            },
+            "dependencies": {
+                "node-fetch": {
+                    "version": "2.6.1",
+                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+                    "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+                }
             }
         },
         "node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+                    "dev": true
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+                    "dev": true
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+                    "dev": true,
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
+            }
         },
         "node-html-parser": {
             "version": "1.4.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3392,9 +3392,9 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "node_modules/nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -7950,9 +7950,9 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nanoid": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-            "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+            "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
         },
         "native-url": {
             "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "axios": "^0.24.0",
         "dotenv": "^10.0.0",
-        "next": "11.1.2",
+        "next": "11.1.3",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-icons": "^4.3.1"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
         "next": "11.1.3",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-icons": "^4.3.1"
+        "react-icons": "^4.3.1",
+        "node-fetch": ">=2.6.7"
     },
     "devDependencies": {
         "eslint": "7.32.0",
-        "eslint-config-next": "11.1.2"
+        "eslint-config-next": "11.1.2",
+        "node-fetch": ">=2.6.7"
     }
 }


### PR DESCRIPTION
* Bumps [ansi-regex](https://github.com/chalk/ansi-regex) from 5.0.0 to 5.0.1.
* Bump next from 11.1.2 to 11.1.3
* Bump nanoid from 3.1.25 to 3.2.0
* Bump follow-redirects from 1.14.5 to 1.14.7
* Bump node-fetch from 2.6.1 to 2.6.7